### PR TITLE
Fix internal package version pins for publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37816,7 +37816,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@devdocsai/core": "0.20.0",
+        "@devdocsai/core": "0.21.0",
         "@floating-ui/react": "^0.25.4",
         "@radix-ui/react-accessible-icon": "^1.0.3",
         "@radix-ui/react-dialog": "^1.0.4",
@@ -37847,41 +37847,12 @@
         "react-dom": "^18 || ^19"
       }
     },
-    "packages/react/node_modules/@devdocsai/core": {
-      "version": "0.20.0",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-search": "^4.20.0",
-        "defaults": "^2.0.2",
-        "type-fest": "^4.3.1"
-      }
-    },
-    "packages/react/node_modules/defaults": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "packages/react/node_modules/type-fest": {
-      "version": "4.41.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/web": {
       "name": "@devdocsai/web",
       "version": "0.21.4",
       "license": "MIT",
       "dependencies": {
-        "@devdocsai/core": "0.20.0",
+        "@devdocsai/core": "0.21.0",
         "@devdocsai/react": "1.0.0"
       },
       "devDependencies": {
@@ -37891,15 +37862,6 @@
         "preact": "^10.17.1",
         "react": "npm:@preact/compat",
         "react-dom": "npm:@preact/compat"
-      }
-    },
-    "packages/web/node_modules/@devdocsai/core": {
-      "version": "0.20.0",
-      "license": "MIT",
-      "dependencies": {
-        "@algolia/client-search": "^4.20.0",
-        "defaults": "^2.0.2",
-        "type-fest": "^4.3.1"
       }
     },
     "packages/web/node_modules/@esbuild/aix-ppc64": {
@@ -38291,16 +38253,6 @@
         "node": ">=12"
       }
     },
-    "packages/web/node_modules/defaults": {
-      "version": "2.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "packages/web/node_modules/esbuild": {
       "version": "0.19.12",
       "dev": true,
@@ -38336,16 +38288,6 @@
         "@esbuild/win32-arm64": "0.19.12",
         "@esbuild/win32-ia32": "0.19.12",
         "@esbuild/win32-x64": "0.19.12"
-      }
-    },
-    "packages/web/node_modules/type-fest": {
-      "version": "4.41.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@floating-ui/react": "^0.25.4",
-    "@devdocsai/core": "0.20.0",
+    "@devdocsai/core": "0.21.0",
     "@radix-ui/react-accessible-icon": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.4",
     "@radix-ui/react-tabs": "^1.0.4",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,7 +28,7 @@
     "prepack": "node scripts/build.js"
   },
   "dependencies": {
-    "@devdocsai/core": "0.20.0",
+    "@devdocsai/core": "0.21.0",
     "@devdocsai/react": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary\n- update @devdocsai/react and @devdocsai/web to depend on @devdocsai/core@0.21.0\n- refresh package-lock workspace metadata so stale nested @devdocsai/core@0.20.0 entries are removed\n\n## Verification\n- npm install --package-lock-only --ignore-scripts\n- nvm install 18.20.8\n- npm ci --ignore-scripts\n- npm run build:packages\n- workspace dependency version check script\n\n## Publish follow-up\nThe failed publish job still needs a fresh npm token for the npm account with read-write access to @devdocsai, then GitHub Actions secret NPM_TOKEN must be updated before rerunning the failed release job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependencies to latest versions for improved stability and performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devdocsorg/devdocsai-js/pull/11)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->